### PR TITLE
add a minimal setup.py and tox.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
 *.pyc
+*.pyo
+
+# editor artifacts
+.*swp
+*~
+
+# test artifacts
+.tox
+.coverage
+*.egg-info

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+
+from setuptools import setup, find_packages
+
+setup(
+    name='glusterapi-python',
+    version='0.1',
+    description='Python client library for GlusterD2',
+    license='GPLv3+',
+    author='Gluster Developers',
+    author_email='gluster-devel@gluster.org',
+    url='https://github.com/gluster/glusterapi-python',
+    packages=find_packages(exclude=['test', 'bin']),
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+envlist = flake8
+
+[testenv]
+install_command = pip install -U {opts} {packages}
+setenv = VIRTUAL_ENV={envdir}
+deps =
+    requests
+    flake8
+
+[testenv:flake8]
+basepython=python2.7
+changedir = {toxinidir}
+commands =
+  flake8 glusterapi setup.py
+
+[flake8]
+ignore = H
+builtins = _
+exclude = .venv,.tox,dist,doc,test,*egg
+show-source = True


### PR DESCRIPTION
This minimal tox and setup.py are based on the Heketi python client api
and can be used to run the flake8 code quality checking tool.

Later tox can be used to run unit tests and as a basis for ci testing.

Followup patch adds some patterns to .gitignore for stuff generated by tox runs and, while I was at it, some editor temporary files.

Please merge PR #4 first, as it resolves some of the flake8 issues and then the tool will run cleanly once added.